### PR TITLE
2021.10.22 update yaml_conf_as_dict function

### DIFF
--- a/fishbase/fish_common.py
+++ b/fishbase/fish_common.py
@@ -661,11 +661,11 @@ def yaml_conf_as_dict(file_path, encoding=None):
     try:
         if sys.version > '3':
             with open(file_path, 'r', encoding=encoding) as f:
-                d = OrderedDict(yaml.load(f.read()))
+                d = OrderedDict(yaml.safe_load(f.read()))
                 return True, d, 'Success'
         else:
             with open(file_path, 'r') as f:
-                d = OrderedDict(yaml.load(f.read()))
+                d = OrderedDict(yaml.safe_load(f.read()))
                 return True, d, 'Success'
     except Exception:
         return False, {}, 'Unknown error'


### PR DESCRIPTION
This PR aims to make sure the project can run without error. The `test_common.py::TestFishCommon::test_yaml_conf_as_dict_01` can fail (running on `sys.version=GCC 7.5.0`). The cause is `fish_common.py::yaml_conf_as_dict`. The error can be reproduced by 'pytest tests/'. After modification, all testcases can pass.