### PR TITLE
set_log_file函数添加encoding参数

### DIFF
--- a/fishbase/fish_logger.py
+++ b/fishbase/fish_logger.py
@@ -130,8 +130,8 @@ class SafeFileHandler(FileHandler):
 # 2018.2.13 edit, remove thread watch
 # 2018.4.23 edit，#19023 增加 docstring
 # 2019.7.16 v1.1.15 #240 edit by Hu Jun
-def set_log_file(local_file=None, file_name_format='%date-%project_name-%log'):
-
+# 2024.10.11 edit 增加encoding
+def set_log_file(local_file=None, file_name_format='%date-%project_name-%log', encoding=None):
     """
     设置日志记录，按照每天一个文件，记录包括 info 以及以上级别的内容；
     日志格式采取日志文件名直接加上日期，比如 2018-05-27.fish_test.log
@@ -139,6 +139,7 @@ def set_log_file(local_file=None, file_name_format='%date-%project_name-%log'):
     :param:
         * local_fie: (string) 日志文件名
         * file_name_format: (string) 日志文件名格式
+        * encoding: (string) 日志文件编码
     :return: 无
 
     举例如下::
@@ -175,7 +176,7 @@ def set_log_file(local_file=None, file_name_format='%date-%project_name-%log'):
     
     # time rotating file handler
     # _tfh = TimedRotatingFileHandler(default_log_file, when="midnight")
-    _tfh = SafeFileHandler(filename=default_log_file, file_name_format=file_name_format)
+    _tfh = SafeFileHandler(filename=default_log_file, file_name_format=file_name_format, encoding=None)
     _tfh.setLevel(logging.INFO)
 
     _formatter = logging.Formatter(


### PR DESCRIPTION
添加encoding参数，避免出现gbk无法编码的错误。我遇到的错误如下：
```
2024-10-11 09:54:13,720 INFO trancode.py[ln:32] G:\动漫\新妹魔王的契约者\[VCB-Studio] Shinmai Maou no Testament BURST [Ma10p_1080p]\CDs\[151216] ｢Metamorphose 1｣／Metamorphose (flac+webp)\Cover.jpg => G:\t\动漫\新妹魔王的契约者\[VCB-Studio] Shinmai Maou no Testament BURST [Ma10p_1080p]\CDs\[151216] ｢Metamorphose 1｣／Metamorphose (flac+webp)\Cover.jpg
--- Logging error ---
Traceback (most recent call last):
  File "D:\Python312\Lib\logging\__init__.py", line 1163, in emit
    stream.write(msg + self.terminator)
UnicodeEncodeError: 'gbk' codec can't encode character '\uff62' in position 135: illegal multibyte sequence
Call stack:
  File "E:\code\python\movie_trancode\trancode.py", line 33, in <module>
    logging.info(file_path + '不是视频文件')
  File "D:\Python312\Lib\logging\__init__.py", line 2216, in info
    root.info(msg, *args, **kwargs)
  File "D:\Python312\Lib\logging\__init__.py", line 1539, in info
    self._log(INFO, msg, args, **kwargs)
  File "D:\Python312\Lib\logging\__init__.py", line 1684, in _log
    self.handle(record)
  File "D:\Python312\Lib\logging\__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "D:\Python312\Lib\logging\__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "D:\Python312\Lib\logging\__init__.py", line 1028, in handle
    self.emit(record)
  File "E:\code\python\movie_trancode\.venv\Lib\site-packages\fishbase\fish_logger.py", line 66, in emit
    FileHandler.emit(self, record)
Message: 'G:\\动漫\\新妹魔王的契约者\\[VCB-Studio] Shinmai Maou no Testament BURST [Ma10p_1080p]\\CDs\\[151216] ｢Metamorphose 1｣／Metamorphose (flac+webp)\\Cover.jpg不是视频文件'
Arguments: ()

```

其中`｢Metamorphose 1｣`无法被GBK编码，需要utf-8或者GB18030.